### PR TITLE
build: add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 dist/
 node_modules/
 [._]*.s[a-v][a-z]


### PR DESCRIPTION
**Pull Request Description:**

This pull request adds the `.env` file to the `.gitignore` file. This is necessary to exclude the `.env` file from version control and prevent sensitive environment variables from being committed to the repository.