### PR TITLE
feat(docker): copy package.json and bun.lock files correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,13 @@ RUN bun install
 RUN bun run build
 
 FROM base AS build-dev-deps
-COPY --from=build /usr/src/app/package.json /usr/src/app/bun.lock .
+COPY --from=build /usr/src/app/package.json /usr/src/app
+COPY --from=build /usr/src/app/bun.lock /usr/src/app
 RUN bun install --frozen-lockfile --production
 
 FROM base AS publish
-COPY --from=build /usr/src/app/package.json /usr/src/app/bun.lock .
+COPY --from=build /usr/src/app/package.json /usr/src/app
+COPY --from=build /usr/src/app/bun.lock /usr/src/app
 COPY --from=build /usr/src/app/dist dist
 COPY --from=build-dev-deps /usr/src/app/node_modules node_modules
 ENV PORT 3000


### PR DESCRIPTION
Copies the package.json and bun.lock files from the build stage to the correct locations in the development and production stages of the Docker image. This ensures that the dependencies are installed correctly in both stages.